### PR TITLE
Fix open file dialog result check

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -12,6 +12,7 @@ from System.Windows.Forms import (
     ListBox,
     Application,
     MessageBox,
+    DialogResult,
 )
 from System.Drawing import Point, Size
 import System.Threading
@@ -80,7 +81,7 @@ class MyForm(Form):
         dialog = OpenFileDialog()
         dialog.Title = "選擇檔案"
         dialog.Filter = "AEDT Files (*.aedt;*.aedtz)|*.aedt;*.aedtz"
-        if dialog.ShowDialog() == 1:
+        if dialog.ShowDialog() == DialogResult.OK:
             fname = dialog.FileName
             if fname.lower().endswith('.aedt') or fname.lower().endswith('.aedtz'):
                 self.queue_list.Items.Add(fname)


### PR DESCRIPTION
## Summary
- ensure the file is added only when the dialog result is OK
- import `DialogResult` to compare with the dialog return value

## Testing
- `python -m py_compile scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_685f470fd090832a9d85d545bb348236