### PR TITLE
Auto simulate queue without start button

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 
 This project contains a small IronPython script that provides a GUI for
 managing a simulation queue.  Users can add files to the queue, reorder or
-remove them and then start a simple simulation process.  Finished items are
-moved to a separate list so you can track what has been processed.
+remove them and items in the queue will be processed automatically in order.
+Finished items are moved to a separate list so you can track what has been
+processed.
+
+Simulation begins as soon as a file is added to the queue, so there is no
+longer a separate "Start" button.
 
 Only `.aedt` or `.aedtz` files can be added to the queue. Run `run.bat` to
 start the application in an Ansys IronPython environment.


### PR DESCRIPTION
## Summary
- drop the manual **Start** button
- automatically start processing the queue when files are added
- block moving or removing the file currently being simulated
- document automatic simulation behavior

## Testing
- `python3 -m py_compile scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_685f4afef62c832aa5a4e402b347f42b