### PR TITLE
Switch queue list to data grid with submit time

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 This project contains a small IronPython script that provides a GUI for
 managing a simulation queue.  Users can add files to the queue, reorder or
 remove them and items in the queue will be processed automatically in order.
-Finished items are moved to a separate list so you can track what has been
-processed.
+The queue is displayed as a grid showing the file name and the submit time for
+each item. Finished items are moved to a separate grid so you can track what
+has been processed.
 
 Simulation begins as soon as a file is added to the queue, so there is no
 longer a separate "Start" button.


### PR DESCRIPTION
## Summary
- switch queue from a `ListBox` to a `DataGridView`
- record submit time for each queued file
- update move/remove logic for grid rows
- document queue grid in README

## Testing
- `python -m py_compile scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_685f56829be0832aa085d88ba316f5df