### PR TITLE
Add non graphical mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@ This project contains a small IronPython script that provides a GUI for
 managing a simulation queue.  Users can add files to the queue, reorder or
 remove them and items in the queue will be processed automatically in order.
 The queue is displayed as a grid showing the file name and the submit time for
-each item. Finished items are moved to a separate grid so you can track what
-has been processed.
+each item. A "Non Graphical" column indicates whether the item will be solved
+with the `-ng` option. Finished items are moved to a separate grid so you can
+track what has been processed.
 
 Simulation begins as soon as a file is added to the queue, so there is no
 longer a separate "Start" button.
 
 Only `.aedt` or `.aedtz` files can be added to the queue. Run `run.bat` to
 start the application in an Ansys IronPython environment.
+
+Before adding a file you can tick the **Non Graphical** check box to run that
+simulation in non-graphical mode. Each file can be configured independently.


### PR DESCRIPTION
## Summary
- support running jobs in non-graphical mode
- track NG mode per queued item in new column
- document new NG checkbox

## Testing
- `python3 -m py_compile scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_685f5ce0cfe0832a9ccb0c2a632ccaba