### PR TITLE
Allow user defined ansysedt path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Simulation begins as soon as a file is added to the queue, so there is no
 longer a separate "Start" button.
 
 Only `.aedt` or `.aedtz` files can be added to the queue. Run `run.bat` to
-start the application in an Ansys IronPython environment.
+start the application in an Ansys IronPython environment. Edit the
+`ANSYSEDT_PATH` variable inside `run.bat` if your installation lives in a
+different location.
 
 Before adding a file you can tick the **Non Graphical** check box to run that
 simulation in non-graphical mode. Each file can be configured independently.

--- a/run.bat
+++ b/run.bat
@@ -1,6 +1,8 @@
 @echo off
-echo 執行 IronPython 腳本...
+REM Configure the path to ansysedt here
+set "ANSYSEDT_PATH=C:\Program Files\ANSYS Inc\v251\AnsysEM\ansysedt"
 
-"C:\Program Files\ANSYS Inc\v251\AnsysEM\common\IronPython\ipy64.exe" .\scheduler.py
+echo 執行 IronPython 腳本...
+"C:\Program Files\ANSYS Inc\v251\AnsysEM\common\IronPython\ipy64.exe" scheduler.py
 
 pause

--- a/scheduler.py
+++ b/scheduler.py
@@ -25,12 +25,18 @@ from System.IO import Path
 import System.Threading
 import threading
 import subprocess
+import os
 
 class MyForm(Form):
     def __init__(self):
         self.Text = "AEDT Scheduler"
         self.Size = Size(840, 550)
         Control.CheckForIllegalCrossThreadCalls = False
+
+        self.ansysedt_path = os.environ.get(
+            "ANSYSEDT_PATH",
+            r"C:\Program Files\ANSYS Inc\v251\AnsysEM\ansysedt",
+        )
 
         # 狀態顯示
         self.status_label = Label()
@@ -251,11 +257,10 @@ class MyForm(Form):
             self.status_label.Text = "Simulating: " + file_path
             start_time = System.DateTime.Now
             if file_path.lower().endswith('.aedt'):
-                cmd = (
-                    r'"C:\\Program Files\\ANSYS Inc\\v251\\AnsysEM\\ansysedt" '
-                    r'-batchsolve {ng}"{file}"'.format(
-                        ng='-ng ' if ng_flag else '', file=file_path
-                    )
+                cmd = '"{exe}" -batchsolve {ng}"{file}"'.format(
+                    exe=self.ansysedt_path,
+                    ng='-ng ' if ng_flag else '',
+                    file=file_path,
                 )
                 subprocess.call(cmd, shell=True)
             else:


### PR DESCRIPTION
## Summary
- read the `ANSYSEDT_PATH` environment variable in `scheduler.py`
- default path falls back to `C:\Program Files\ANSYS Inc\v251\AnsysEM\ansysedt`
- set `ANSYSEDT_PATH` in `run.bat`
- update README with instructions for changing the path

## Testing
- `python3 -m py_compile scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_685f814d68e4832a96fdf80deaafc09f