### PR TITLE
Enable multi file selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ track what has been processed.
 Simulation begins as soon as a file is added to the queue, so there is no
 longer a separate "Start" button.
 
-Only `.aedt` or `.aedtz` files can be added to the queue. Run `run.bat` to
-start the application in an Ansys IronPython environment. Edit the
-`ANSYSEDT_PATH` variable inside `run.bat` if your installation lives in a
-different location.
+Use the **Add File** button to select one or more `.aedt` or `.aedtz` files.
+Run `run.bat` to start the application in an Ansys IronPython environment.
+Edit the `ANSYSEDT_PATH` variable inside `run.bat` if your installation lives
+in a different location.
 
 Before adding a file you can tick the **Non Graphical** check box to run that
 simulation in non-graphical mode. Each file can be configured independently.

--- a/scheduler.py
+++ b/scheduler.py
@@ -156,23 +156,26 @@ class MyForm(Form):
         dialog = OpenFileDialog()
         dialog.Title = "選擇檔案"
         dialog.Filter = "AEDT Files (*.aedt;*.aedtz)|*.aedt;*.aedtz"
+        dialog.Multiselect = True
         if dialog.ShowDialog() == DialogResult.OK:
-            fname = dialog.FileName
-            if fname.lower().endswith('.aedt') or fname.lower().endswith('.aedtz'):
-                self.queue_paths.append(fname)
-                submit_time = System.DateTime.Now
-                self.queue_times.append(submit_time)
-                self.queue_ngs.append(self.ng_checkbox.Checked)
-                self.queue_grid.Rows.Add(
-                    Path.GetFileName(fname),
-                    "Yes" if self.ng_checkbox.Checked else "No",
-                    submit_time.ToString(),
-                    fname,
-                )
-                if not self.is_simulating:
-                    self.start_simulation()
-            else:
-                MessageBox.Show("Only .aedt or .aedtz files are allowed.")
+            files_added = False
+            for fname in dialog.FileNames:
+                if fname.lower().endswith('.aedt') or fname.lower().endswith('.aedtz'):
+                    self.queue_paths.append(fname)
+                    submit_time = System.DateTime.Now
+                    self.queue_times.append(submit_time)
+                    self.queue_ngs.append(self.ng_checkbox.Checked)
+                    self.queue_grid.Rows.Add(
+                        Path.GetFileName(fname),
+                        "Yes" if self.ng_checkbox.Checked else "No",
+                        submit_time.ToString(),
+                        fname,
+                    )
+                    files_added = True
+                else:
+                    MessageBox.Show("Only .aedt or .aedtz files are allowed.")
+            if files_added and not self.is_simulating:
+                self.start_simulation()
 
     def remove_file(self, sender, event):
         index = -1


### PR DESCRIPTION
## Summary
- allow selecting multiple files in the queue dialog
- document multi-file support in the README

## Testing
- `python3 -m py_compile scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_685f860054c4832a860a0ce234d826b8