### PR TITLE
Handle AEDT lock files when queuing

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -197,6 +197,12 @@ class MyForm(Form):
             files_added = False
             for fname in dialog.FileNames:
                 if fname.lower().endswith('.aedt') or fname.lower().endswith('.aedtz'):
+                    lock_path = fname + '.lock'
+                    if os.path.isfile(lock_path):
+                        try:
+                            os.remove(lock_path)
+                        except Exception:
+                            pass
                     self.queue_paths.append(fname)
                     submit_time = System.DateTime.Now
                     self.queue_times.append(submit_time)


### PR DESCRIPTION
## Summary
- delete `.aedt.lock` files before queuing their corresponding project

## Testing
- `python3 -m py_compile scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_685f9d5c38d8832abd83a8d5be07c9b7