### PR TITLE
Minimize batch console

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -3,4 +3,5 @@ REM Configure the path to ansysedt here
 set "ANSYSEDT_PATH=C:\Program Files\ANSYS Inc\v251\AnsysEM\ansysedt"
 
 echo 執行 IronPython 腳本...
-"C:\Program Files\ANSYS Inc\v251\AnsysEM\common\IronPython\ipy64.exe" scheduler.py
+REM Launch minimized to avoid showing a console window
+start "" /min "C:\Program Files\ANSYS Inc\v251\AnsysEM\common\IronPython\ipy64.exe" scheduler.py


### PR DESCRIPTION
## Summary
- minimize the console window when `run.bat` launches the IronPython script

## Testing
- `python3 -m py_compile scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_685fa52160f4832a95399a737fdb00c9