### PR TITLE
Enable folder opening on path double-click

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ simulation in non-graphical mode. Each file can be configured independently.
 * 要使用程式必須修改 `run.bat` 內的兩個路徑：
   1. IronPython `ipy64.exe` 的範例路徑。
   2. `ANSYSEDT_PATH` 設定的 `ansysedt.exe` 目錄。
+* 在排程列表或完成列表中，雙擊 **Full Path** 欄位可開啟該檔案所在資料夾。
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -109,6 +109,7 @@ class MyForm(Form):
         )
         self.queue_grid.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
         self.queue_grid.ShowCellToolTips = False
+        self.queue_grid.CellDoubleClick += self.open_queue_folder
 
         q_file_col = DataGridViewTextBoxColumn()
         q_file_col.HeaderText = "File"
@@ -143,6 +144,7 @@ class MyForm(Form):
         )
         self.finished_grid.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
         self.finished_grid.ShowCellToolTips = False
+        self.finished_grid.CellDoubleClick += self.open_finished_folder
 
         file_col = DataGridViewTextBoxColumn()
         file_col.HeaderText = "File"
@@ -311,6 +313,22 @@ class MyForm(Form):
                 self.tooltip.SetToolTip(self.finished_grid, text)
         else:
             self.tooltip.SetToolTip(self.finished_grid, "")
+
+    def open_queue_folder(self, sender, event):
+        if event.RowIndex >= 0 and event.RowIndex < len(self.queue_paths):
+            folder = os.path.dirname(self.queue_paths[event.RowIndex])
+            try:
+                subprocess.Popen(["explorer", folder])
+            except Exception:
+                MessageBox.Show("Unable to open folder.")
+
+    def open_finished_folder(self, sender, event):
+        if event.RowIndex >= 0 and event.RowIndex < len(self.finished_paths):
+            folder = os.path.dirname(self.finished_paths[event.RowIndex])
+            try:
+                subprocess.Popen(["explorer", folder])
+            except Exception:
+                MessageBox.Show("Unable to open folder.")
 
     def start_simulation(self, sender=None, event=None):
         if self.is_simulating:


### PR DESCRIPTION
## Summary
- open containing folder when double-clicking a path in either grid
- document the new double-click behaviour

## Testing
- `python3 -m py_compile scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_685faf4acb54832a8216703c3c9bd060