### PR TITLE
Add settings dialog with persisted AEDT path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ longer a separate "Start" button.
 
 Use the **Add File** button to select one or more `.aedt` or `.aedtz` files.
 Run `run.bat` to start the application in an Ansys IronPython environment.
-Edit the `ANSYSEDT_PATH` variable inside `run.bat` if your installation lives
-in a different location.
+Use the **Settings** menu to set the full path to `ansysedt.exe`.  The value is
+stored in `config.json` so you only need to configure it once.
 
 Before adding a file you can tick the **Non Graphical** check box to run that
 simulation in non-graphical mode. Each file can be configured independently.
@@ -26,8 +26,7 @@ simulation in non-graphical mode. Each file can be configured independently.
 ## 使用說明
 
 * 請將 `scheduler.py` 和 `run.bat` 置於同一目錄中使用。
-* 要使用程式必須修改 `run.bat` 內的兩個路徑：
-  1. IronPython `ipy64.exe` 的範例路徑。
-  2. `ANSYSEDT_PATH` 設定的 `ansysedt.exe` 目錄。
+* 使用前可修改 `run.bat` 中 IronPython `ipy64.exe` 的路徑。
+* `ansysedt.exe` 的位置可以在程式的 **Settings** 視窗中設定，並會儲存在 `config.json`。
 * 在排程列表或完成列表中，雙擊 **Full Path** 欄位可開啟該檔案所在資料夾。
 

--- a/run.bat
+++ b/run.bat
@@ -1,5 +1,5 @@
 @echo off
-REM Configure the path to ansysedt here
+REM Optional: set ANSYSEDT_PATH here to override config.json
 set "ANSYSEDT_PATH=C:\Program Files\ANSYS Inc\v251\AnsysEM\ansysedt"
 
 echo 執行 IronPython 腳本...

--- a/scheduler.py
+++ b/scheduler.py
@@ -29,13 +29,76 @@ from System.Windows.Forms import (
     SizeType,
     FormWindowState,
     DataGridViewColumnSortMode,
+    MenuStrip,
+    ToolStripMenuItem,
+    TextBox,
 )
-from System.Drawing import Size, Color
+from System.Drawing import Size, Color, Point
 from System.IO import Path
 import System.Threading
 import threading
 import subprocess
 import os
+import json
+
+CONFIG_FILE = "config.json"
+
+
+class SettingsForm(Form):
+    def __init__(self, current_path):
+        self.Text = "Settings"
+        self.Size = Size(420, 120)
+        self.FormBorderStyle = FormBorderStyle.FixedDialog
+        self.MaximizeBox = False
+        self.MinimizeBox = False
+
+        label = Label()
+        label.Text = "ANSYSEDT Path:"
+        label.Location = Point(10, 15)
+        label.AutoSize = True
+
+        self.path_box = TextBox()
+        self.path_box.Text = current_path
+        self.path_box.Location = Point(110, 12)
+        self.path_box.Width = 250
+
+        browse_btn = Button()
+        browse_btn.Text = "Browse"
+        browse_btn.Location = Point(370, 10)
+        browse_btn.Click += self.browse
+
+        ok_btn = Button()
+        ok_btn.Text = "OK"
+        ok_btn.Location = Point(220, 50)
+        ok_btn.Click += self.ok_clicked
+
+        cancel_btn = Button()
+        cancel_btn.Text = "Cancel"
+        cancel_btn.Location = Point(300, 50)
+        cancel_btn.Click += self.cancel_clicked
+
+        self.Controls.Add(label)
+        self.Controls.Add(self.path_box)
+        self.Controls.Add(browse_btn)
+        self.Controls.Add(ok_btn)
+        self.Controls.Add(cancel_btn)
+
+    def browse(self, sender, event):
+        dialog = OpenFileDialog()
+        dialog.Title = "Select ansysedt.exe"
+        dialog.Filter = "ansysedt.exe|ansysedt.exe"
+        dialog.FileName = "ansysedt.exe"
+        if dialog.ShowDialog() == DialogResult.OK:
+            self.path_box.Text = dialog.FileName
+
+    def ok_clicked(self, sender, event):
+        self.selected_path = self.path_box.Text.strip()
+        self.DialogResult = DialogResult.OK
+        self.Close()
+
+    def cancel_clicked(self, sender, event):
+        self.DialogResult = DialogResult.Cancel
+        self.Close()
 
 
 class MyForm(Form):
@@ -51,6 +114,16 @@ class MyForm(Form):
             "ANSYSEDT_PATH",
             r"C:\Program Files\ANSYS Inc\v251\AnsysEM\ansysedt",
         )
+        self.load_config()
+
+        # Menu
+        self.menu_strip = MenuStrip()
+        self.menu_strip.Dock = DockStyle.Top
+        settings_item = ToolStripMenuItem("Settings")
+        settings_item.Click += self.open_settings
+        self.menu_strip.Items.Add(settings_item)
+        self.MainMenuStrip = self.menu_strip
+        self.Controls.Add(self.menu_strip)
 
         # 狀態顯示
         self.status_label = Label()
@@ -208,6 +281,28 @@ class MyForm(Form):
 
     def on_load(self, sender, event):
         self.WindowState = FormWindowState.Normal
+
+    def load_config(self):
+        try:
+            if os.path.isfile(CONFIG_FILE):
+                with open(CONFIG_FILE, "r") as f:
+                    data = json.load(f)
+                    self.ansysedt_path = data.get("ansysedt_path", self.ansysedt_path)
+        except Exception:
+            pass
+
+    def save_config(self):
+        try:
+            with open(CONFIG_FILE, "w") as f:
+                json.dump({"ansysedt_path": self.ansysedt_path}, f)
+        except Exception:
+            MessageBox.Show("Unable to save configuration.")
+
+    def open_settings(self, sender, event):
+        dlg = SettingsForm(self.ansysedt_path)
+        if dlg.ShowDialog() == DialogResult.OK:
+            self.ansysedt_path = dlg.selected_path
+            self.save_config()
 
     def highlight_current_row(self):
         for i in range(self.queue_grid.Rows.Count):


### PR DESCRIPTION
## Summary
- add `SettingsForm` to allow customizing path to `ansysedt.exe`
- store chosen path in `config.json`
- load config at startup and provide **Settings** menu option
- document new behaviour in README
- clarify environment variable in `run.bat`

## Testing
- `python3 -m py_compile scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_68630568dd6c832aa01dd2f17f8d589b